### PR TITLE
Added function NaNMath.sum for Float64 arrays

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,5 +9,17 @@ NaNMath.log(-100) # NaN
 NaNMath.pow(-1.5,2.3) # NaN
 ```
 
+In addition this package provides functions that aggregate one dimensional arrays and ignore elements that are NaN.
+The following functions are implemented:
+
+```
+sum
+```
+
+Example:
+```julia
+using NaNMath; nm=NaNMath
+nm.sum([1., 2., NaN]) # result: 3.0
+```
 
 [![Build Status](https://travis-ci.org/mlubin/NaNMath.jl.svg?branch=master)](https://travis-ci.org/mlubin/NaNMath.jl)

--- a/src/NaNMath.jl
+++ b/src/NaNMath.jl
@@ -1,3 +1,4 @@
+VERSION >= v"0.4.0-dev+6521" && __precompile__()
 module NaNMath
 
 for f in (:sin, :cos, :tan, :asin, :acos, :acosh, :atanh, :log, :log2, :log10,
@@ -14,5 +15,25 @@ end
 pow(x::Float64, y::Float64) = ccall((:pow,Base.Math.libm),  Float64, (Float64,Float64), x, y)
 pow(x::Float32, y::Float32) = ccall((:powf,Base.Math.libm), Float32, (Float32,Float32), x, y)
 pow(x,y) = pow(float(x),float(y))
+
+function sum(x::Array{Float64,1})
+    result = NaN
+    for i = x
+        if !isnan(i)
+            if isnan(result)
+                result = i
+            else
+                result += i
+            end
+        end
+    end
+    if size(x)[1] == 0
+        result = 0.0
+    end
+    if isnan(result)
+        Base.warn_once("All elements of the array, passed to \"sum\" are NaN!")
+    end
+    return result
+end
 
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,3 +4,6 @@ using Base.Test
 @test isnan(NaNMath.log(-10))
 @test isnan(NaNMath.log1p(-100))
 @test isnan(NaNMath.pow(-1.5,2.3))
+@test NaNMath.sum([1., 2., NaN]) == 3.0
+@test isnan(NaNMath.sum([NaN, NaN]))
+@test NaNMath.sum([Float64[]]) == 0.0


### PR DESCRIPTION
I added the function sum. Currently, it is implemented for one dimensional Float64 arrays, which is all what I need. Before I continue to implement the other array functions, I would like to get feedback if my approach is acceptable, or how to improve it.