### PR TITLE
drop support for julia 0.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ os:
   - linux
   - osx
 julia:
-  - release
+  - 0.4
   - nightly
 notifications:
   email: false

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,1 @@
-julia 0.3
-Compat
+julia 0.4

--- a/src/NaNMath.jl
+++ b/src/NaNMath.jl
@@ -1,7 +1,5 @@
-VERSION >= v"0.4.0-dev+6521" && __precompile__()
+__precompile__()
 module NaNMath
-
-using Compat
 
 for f in (:sin, :cos, :tan, :asin, :acos, :acosh, :atanh, :log, :log2, :log10,
           :lgamma, :log1p)


### PR DESCRIPTION
Looks like NaNMath hasn't been tagged in a while, will do so after this.