### PR TITLE
implement sqrt

### DIFF
--- a/src/NaNMath.jl
+++ b/src/NaNMath.jl
@@ -11,6 +11,10 @@ for f in (:sin, :cos, :tan, :asin, :acos, :acosh, :atanh, :log, :log2, :log10,
     end
 end
 
+# Would be more efficient to remove the domain check in Base.sqrt(),
+# but this doesn't seem easy to do.
+sqrt(x::Real) = x < 0.0 ? NaN : Base.sqrt(x)
+
 # Don't override built-in ^ operator
 pow(x::Float64, y::Float64) = ccall((:pow,Base.Math.libm),  Float64, (Float64,Float64), x, y)
 pow(x::Float32, y::Float32) = ccall((:powf,Base.Math.libm), Float32, (Float32,Float32), x, y)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,6 +4,8 @@ using Base.Test
 @test isnan(NaNMath.log(-10))
 @test isnan(NaNMath.log1p(-100))
 @test isnan(NaNMath.pow(-1.5,2.3))
+@test isnan(NaNMath.sqrt(-5))
+@test NaNMath.sqrt(5) == Base.sqrt(5)
 @test NaNMath.sum([1., 2., NaN]) == 3.0
 @test isnan(NaNMath.sum([NaN, NaN]))
 @test NaNMath.sum(Float64[]) == 0.0


### PR DESCRIPTION
Closes #9 
Would be nicer to remove the domain check inside of ``Base.sqrt()``, but this at least gives the correct behavior.