### PR TITLE
Add IEEE 754-2008 compliant min and max

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ minimum
 mean
 var
 std
+min
+max
 ```
 
 Example:

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -15,3 +15,25 @@ using Base.Test
 @test NaNMath.mean([1., 2., NaN]) == 1.5
 @test NaNMath.var([1., 2., NaN]) == 0.5
 @test NaNMath.std([1., 2., NaN]) == 0.7071067811865476
+
+@test NaNMath.min(1, 2) == 1
+@test NaNMath.min(1.0, 2.0) == 1.0
+@test NaNMath.min(1, 2.0) == 1.0
+@test NaNMath.min(BigFloat(1.0), 2.0) == BigFloat(1.0)
+@test NaNMath.min(BigFloat(1.0), BigFloat(2.0)) == BigFloat(1.0)
+@test NaNMath.min(NaN, 1) == 1.0
+@test NaNMath.min(NaN32, 1) == 1.0f0
+@test isnan(NaNMath.min(NaN, NaN))
+@test isnan(NaNMath.min(NaN))
+@test NaNMath.min(NaN, NaN, 0.0, 1.0) == 0.0
+
+@test NaNMath.max(1, 2) == 2
+@test NaNMath.max(1.0, 2.0) == 2.0
+@test NaNMath.max(1, 2.0) == 2.0
+@test NaNMath.max(BigFloat(1.0), 2.0) == BigFloat(2.0)
+@test NaNMath.max(BigFloat(1.0), BigFloat(2.0)) == BigFloat(2.0)
+@test NaNMath.max(NaN, 1) == 1.0
+@test NaNMath.max(NaN32, 1) == 1.0f0
+@test isnan(NaNMath.max(NaN, NaN))
+@test isnan(NaNMath.max(NaN))
+@test NaNMath.max(NaN, NaN, 0.0, 1.0) == 1.0


### PR DESCRIPTION
The same as `Base.min` and `Base.max` for Julia < 0.6. On 0.6 and up, ignores `NaN` arguments.