### PR TITLE
Avoid exporting vectorized functions with deprecation

### DIFF
--- a/src/NaNMath.jl
+++ b/src/NaNMath.jl
@@ -9,7 +9,14 @@ for f in (:sin, :cos, :tan, :asin, :acos, :acosh, :atanh, :log, :log2, :log10,
         ($f)(x::Float64) = ccall(($(string(f)),Base.Math.libm), Float64, (Float64,), x)
         ($f)(x::Float32) = ccall(($(string(f,"f")),Base.Math.libm), Float32, (Float32,), x)
         ($f)(x::Real) = ($f)(float(x))
-        Compat.@dep_vectorize_1arg Number $f
+        if VERSION >= v"0.5.0-dev+4002"
+            function ($f){T<:Number}(x::AbstractArray{T})
+                Base.depwarn("$f{T<:Number}(x::AbstractArray{T}) is deprecated, use $f.(x) instead.", $f)
+                return ($f).(x)
+            end
+        else
+            ($f){T<:Number}(x::AbstractArray{T}) = broadcast($f, x)
+        end
     end
 end
 


### PR DESCRIPTION
Using `@dep_vectorize_1arg` actually exports the functions, which causes errors since Base also exports the functions. This PR avoids exporting by manually constructing the deprecation rather than using the macro.