### PR TITLE
Fix bug in `extrema`

### DIFF
--- a/src/NaNMath.jl
+++ b/src/NaNMath.jl
@@ -141,7 +141,8 @@ function extrema{T<:AbstractFloat}(x::AbstractArray{T})
         if !isnan(i)
             if (isnan(resultmin) || i < resultmin)
                 resultmin = i
-            elseif (isnan(resultmax) || i > resultmax)
+            end
+            if (isnan(resultmax) || i > resultmax)
                 resultmax = i
             end
         end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -16,7 +16,10 @@ using Base.Test
 @test NaNMath.minimum([1., 2., NaN]) == 1.0
 @test NaNMath.minimum([1. 2.; NaN 1.]) == 1.0
 @test NaNMath.extrema([1., 2., NaN]) == (1.0, 2.0)
+@test NaNMath.extrema([2., 1., NaN]) == (1.0, 2.0)
 @test NaNMath.extrema([1. 2.; NaN 1.]) == (1.0, 2.0)
+@test NaNMath.extrema([2. 1.; 1. NaN]) == (1.0, 2.0)
+@test NaNMath.extrema([NaN, -1., NaN]) == (-1.0, -1.0)
 @test NaNMath.mean([1., 2., NaN]) == 1.5
 @test NaNMath.mean([1. 2.; NaN 3.]) == 2.0
 @test NaNMath.var([1., 2., NaN]) == 0.5


### PR DESCRIPTION
The existing implementation of `extrema` would not find the maximum value if it was the first in the list because of the `elseif` control flow.  This PR fixes this and adds a test.  I tentatively suggest that future tests should not always use monotonically-increasing positive whole values!

I found this when using GR with Plots.jl, and my `zcolor` values had the maximum as the first value, leading to numbers 'normalised' larger than 1.