### PR TITLE
Fix failure on 1.0 by adding Compat dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ os:
 #  - osx # backlogged
 julia:
   - 0.6
+  - 0.7
   - nightly
 notifications:
   email: false

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,1 +1,2 @@
 julia 0.6
+Compat 0.47

--- a/src/NaNMath.jl
+++ b/src/NaNMath.jl
@@ -1,6 +1,8 @@
 __precompile__()
 module NaNMath
 
+using Compat
+
 const libm = Base.libm_name
 
 for f in (:sin, :cos, :tan, :asin, :acos, :acosh, :atanh, :log, :log2, :log10,
@@ -57,7 +59,7 @@ function sum(x::AbstractArray{T}) where T<:AbstractFloat
     end
 
     if isnan(result)
-        Base.warn_once("All elements of the array, passed to \"sum\" are NaN!")
+        Compat.@warn "All elements of the array, passed to \"sum\" are NaN!"
     end
     return result
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,5 @@
 using NaNMath
-using Base.Test
+using Compat.Test
 
 @test isnan(NaNMath.log(-10))
 @test isnan(NaNMath.log1p(-100))


### PR DESCRIPTION
I don't think we have something like `warn_once` anymore so I've made it a `@warn`. Many packages depend on `NaNMath` so it would be great to get a fixed release out before tomorrow evening if possible.