### PR TITLE
Use Base's `sum` instead of rebuilding it

### DIFF
--- a/src/NaNMath.jl
+++ b/src/NaNMath.jl
@@ -39,27 +39,8 @@ using NaNMath as nm
 nm.sum([1., 2., NaN]) # result: 3.0
 ```
 """
-function sum(x::AbstractArray{T}) where T<:AbstractFloat
-    if length(x) == 0
-        result = zero(eltype(x))
-    else
-        result = convert(eltype(x), NaN)
-        for i in x
-            if !isnan(i)
-                if isnan(result)
-                    result = i
-                else
-                    result += i
-                end
-            end
-        end
-    end
-
-    if isnan(result)
-        @warn "All elements of the array, passed to \"sum\" are NaN!"
-    end
-    return result
-end
+sum(x; kwargs...) = sum(x .* (!isnan).(x); kwargs...)
+sum(f::Function, x; kwargs...) = sum(f.(x); kwargs...)
 
 """
 NaNMath.maximum(A)


### PR DESCRIPTION
This also allows for functions as first argument and trailing kwargs arguments, like in, e.g.,

```julia
julia> NaNMath.sum(sin, [0.0 NaN; 1.0 2.0], dims=2)
2×1 Array{Float64,2}:
 0.0
 1.7507684116335782

julia> NaNMath.sum(sin, [0.0 NaN; 1.0 2.0], dims=1)
1×2 Array{Float64,2}:
 0.841471  0.909297

julia> NaNMath.sum(sin, [1.0, NaN, 2.0])
1.7507684116335782
```