### PR TITLE
Add median function implementation

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "NaNMath"
 uuid = "77ba4419-2d1f-58cd-9bb1-8ffee604a2e3"
 repo = "https://github.com/mlubin/NaNMath.jl.git"
 authors = ["Miles Lubin"]
-version = "0.3.3"
+version = "0.3.4"
 
 [deps]
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ maximum
 minimum
 extrema
 mean
+median
 var
 std
 min

--- a/src/NaNMath.jl
+++ b/src/NaNMath.jl
@@ -87,7 +87,7 @@ function median(x::AbstractVector{<:AbstractFloat})
 
     n = length(x)
     if n == 0
-        return NaN
+        return convert(eltype(x), NaN)
     elseif isodd(n)
         ind = ceil(Int, n/2)
         return x[ind]
@@ -352,4 +352,3 @@ for f in (:min, :max)
 end
 
 end
-

--- a/src/NaNMath.jl
+++ b/src/NaNMath.jl
@@ -85,8 +85,7 @@ function median(x::AbstractArray{T}) where T<:AbstractFloat
         x = collect(Iterators.flatten(x))
     end
 
-    filter!(el->!isnan(el), x)
-    sort!(x)
+    x = sort(filter(!isnan, x))
 
     n = length(x)
     if n == 0

--- a/src/NaNMath.jl
+++ b/src/NaNMath.jl
@@ -79,11 +79,9 @@ NaNMath.median([1., 2., NaN]) # result: 1.5
 NaNMath.median([NaN]) # result: NaN
 ```
 """
-function median(x::AbstractArray{T}) where T<:AbstractFloat
+median(x::AbstractArray{<:AbstractFloat}) = median(collect(Iterators.flatten(x)))
 
-    if ndims(x) > 1
-        x = collect(Iterators.flatten(x))
-    end
+function median(x::AbstractVector{<:AbstractFloat})
 
     x = sort(filter(!isnan, x))
 

--- a/src/NaNMath.jl
+++ b/src/NaNMath.jl
@@ -72,11 +72,17 @@ NaNMath.median(A)
     Returns NaN for an empty array or array containing NaNs only.
 
 ##### Examples:
-```julia
-using NaNMath
-NaNMath.median([1., 2., 3., NaN]) # result: 2.
-NaNMath.median([1., 2., NaN]) # result: 1.5
-NaNMath.median([NaN]) # result: NaN
+```jldoctest
+julia> using NaNMath
+
+julia> NaNMath.median([1., 2., 3., NaN])
+2.
+
+julia> NaNMath.median([1., 2., NaN])
+1.5
+
+julia> NaNMath.median([NaN])
+NaN
 ```
 """
 median(x::AbstractArray{<:AbstractFloat}) = median(collect(Iterators.flatten(x)))

--- a/src/NaNMath.jl
+++ b/src/NaNMath.jl
@@ -62,6 +62,33 @@ function sum(x::AbstractArray{T}) where T<:AbstractFloat
 end
 
 """
+NaNMath.median(A)
+"""
+function median(x::AbstractArray{T}) where T<:AbstractFloat
+
+    if ndims(x) > 1
+        x = collect(Iterators.flatten(x))
+    end
+
+    filter!(el->!isnan(el), x)
+    sort!(x)
+
+    n = length(x)
+    if n == 0
+        return NaN
+    elseif isodd(n)
+        ind = ceil(Int, n/2)
+        return x[ind]
+    else
+        ind = Int(n/2)
+        lower = x[ind]
+        upper = x[ind+1]
+        return (lower + upper) / 2
+    end
+
+end
+
+"""
 NaNMath.maximum(A)
 
 ##### Args:

--- a/src/NaNMath.jl
+++ b/src/NaNMath.jl
@@ -63,6 +63,21 @@ end
 
 """
 NaNMath.median(A)
+
+##### Args:
+* `A`: An array of floating point numbers
+
+##### Returns:
+*   Returns the median of all elements in the array, ignoring NaN's.
+    Returns NaN for an empty array or array containing NaNs only.
+
+##### Examples:
+```julia
+using NaNMath
+NaNMath.median([1., 2., 3., NaN]) # result: 2.
+NaNMath.median([1., 2., NaN]) # result: 1.5
+NaNMath.median([NaN]) # result: NaN
+```
 """
 function median(x::AbstractArray{T}) where T<:AbstractFloat
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -25,6 +25,17 @@ using Test
 @test NaNMath.var([1., 2., NaN]) == 0.5
 @test NaNMath.std([1., 2., NaN]) == 0.7071067811865476
 
+@test NaNMath.median([1.]) == 1.
+@test NaNMath.median([1., NaN]) == 1.
+@test NaNMath.median([NaN, 1., 3.]) == 2.
+@test NaNMath.median([1., 3., 2., NaN]) == 2.
+@test NaNMath.median([NaN, 1, 3]) == 2.
+@test NaNMath.median([1, 2, NaN]) == 1.5
+@test NaNMath.median([1 2; NaN NaN]) == 1.5
+@test NaNMath.median([NaN 2; 1 NaN]) == 1.5
+@test isnan(NaNMath.median(Float64[]))
+@test isnan(NaNMath.median([NaN]))
+
 @test NaNMath.min(1, 2) == 1
 @test NaNMath.min(1.0, 2.0) == 1.0
 @test NaNMath.min(1, 2.0) == 1.0

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -34,6 +34,7 @@ using Test
 @test NaNMath.median([1 2; NaN NaN]) == 1.5
 @test NaNMath.median([NaN 2; 1 NaN]) == 1.5
 @test isnan(NaNMath.median(Float64[]))
+@test isnan(NaNMath.median(Float32[]))
 @test isnan(NaNMath.median([NaN]))
 
 @test NaNMath.min(1, 2) == 1


### PR DESCRIPTION
The suggested implementation drops the NaNs and takes the median of the rest of the elements.

If the array is NaN-only or empty, the function returns NaN.

Closes #40 .