### PR TITLE
Fix order of promotion and `float` in `pow`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "NaNMath"
 uuid = "77ba4419-2d1f-58cd-9bb1-8ffee604a2e3"
 repo = "https://github.com/mlubin/NaNMath.jl.git"
 authors = ["Miles Lubin"]
-version = "0.3.6"
+version = "0.3.7"
 
 [deps]
 

--- a/src/NaNMath.jl
+++ b/src/NaNMath.jl
@@ -22,9 +22,10 @@ sqrt(x::Real) = x < 0.0 ? NaN : Base.sqrt(x)
 # Don't override built-in ^ operator
 pow(x::Float64, y::Float64) = ccall((:pow,libm),  Float64, (Float64,Float64), x, y)
 pow(x::Float32, y::Float32) = ccall((:powf,libm), Float32, (Float32,Float32), x, y)
-# Need `promote` here, otherwise we'll end up with an infinite recursion
-# in the case of `x` and `y` being different floating types.
-pow(x::Number, y::Number) = pow(promote(float(x), float(y))...)
+# We `promote` first before converting to floating pointing numbers to ensure that
+# e.g. `pow(::Float32, ::Int)` ends up calling `pow(::Float32, ::Float32)`
+pow(x::Number, y::Number) = pow(promote(x, y)...)
+pow(x::T, y::T) where {T<:Number} = pow(float(x), float(y))
 
 """
 NaNMath.sum(A)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,8 +7,13 @@ using Test
 @test isnan(NaNMath.pow(-1.5f0,2.3f0))
 @test isnan(NaNMath.pow(-1.5,2.3f0))
 @test isnan(NaNMath.pow(-1.5f0,2.3))
+@test NaNMath.pow(-1,2) isa Float64
+@test NaNMath.pow(-1.5f0,2) isa Float32
+@test NaNMath.pow(-1.5f0,2//1) isa Float32
 @test NaNMath.pow(-1.5f0,2.3f0) isa Float32
 @test NaNMath.pow(-1.5f0,2.3) isa Float64
+@test NaNMath.pow(-1.5,2) isa Float64
+@test NaNMath.pow(-1.5,2//1) isa Float64
 @test NaNMath.pow(-1.5,2.3f0) isa Float64
 @test NaNMath.pow(-1.5,2.3) isa Float64
 @test isnan(NaNMath.sqrt(-5))


### PR DESCRIPTION
Currently, `pow(-1.5f0, 2) isa Float64` since both arguments are converted to floating point numbers before they are promoted. This PR changes the order of these two operations and hence ensures that `pow(-1.5f0, 2) isa Float32`.