### PR TITLE
Remove libm_name

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,9 +2,10 @@ name = "NaNMath"
 uuid = "77ba4419-2d1f-58cd-9bb1-8ffee604a2e3"
 repo = "https://github.com/mlubin/NaNMath.jl.git"
 authors = ["Miles Lubin"]
-version = "1.0.0"
+version = "1.0.1"
 
 [deps]
+OpenLibm_jll = "05823500-19ac-5b8b-9628-191a04bc5112"
 
 [compat]
 julia = "1.6"

--- a/src/NaNMath.jl
+++ b/src/NaNMath.jl
@@ -1,6 +1,7 @@
 module NaNMath
 
-const libm = Base.libm_name
+using OpenLibm_jll
+const libm = OpenLibm_jll.libopenlibm
 
 for f in (:sin, :cos, :tan, :asin, :acos, :acosh, :atanh, :log, :log2, :log10,
           :lgamma, :log1p)


### PR DESCRIPTION
Not specifying the `libm_name` will pick the system libm. This is in preparation for https://github.com/JuliaLang/julia/pull/42299 where most of the pkgeval failures will be resolved with NaNMath being updated.